### PR TITLE
Add etl 12doctubre

### DIFF
--- a/RunETL12doctubre/README.md
+++ b/RunETL12doctubre/README.md
@@ -1,0 +1,21 @@
+# How to execute the ETL for 12doctubre
+
+## Prerequisites
+2. Docker is installed and running.
+3. The user has read access to the 12doctubre Docker Hub repository containing the ETL image.
+4. The HONEUR OMOP CDM database is running in a Docker container named `postgres`:
+    * Check this by running `docker ps`. You should see the `postgres` container listed as running and healthy.
+    * See [https://github.com/solventrix/Honeur-Setup/blob/master/OMOPCDM/README.md](https://github.com/solventrix/Honeur-Setup/blob/master/README.md) for more info.
+
+## Execution steps
+1. Open a terminal window 
+2. Download the installation script:
+    * `curl -L https://raw.githubusercontent.com/solventrix/Honeur-Setup/master/RunETL12doctubre/runETL.sh --output runETL.sh && chmod +x runETL.sh`
+3. Execute the `runETL.sh` script by running `./runETL.sh` form inside the directory where the script is located.
+4. The script will request for:
+    * the path to the folder that contains the input CSV data files
+    * the username and password to connect to the OMOP CDM database (a running Docker container named `postgres`)
+    * the tag name for the Docker Hub image
+    * the verbosity level [DEBUG, INFO, WARNING, ERROR]
+5. The script will run the ETL code and show the output of the code
+6. The `etl.log` log file will be available in the `log` folder

--- a/RunETL12doctubre/docker-compose.yml
+++ b/RunETL12doctubre/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   etl:
-    image: edence/12doctubre:tag_name
+    image: edence/12doctubre:image_tag
     volumes:
       - "./log:/log"
       - "data_folder:/data"

--- a/RunETL12doctubre/docker-compose.yml
+++ b/RunETL12doctubre/docker-compose.yml
@@ -2,10 +2,10 @@ version: '3.5'
 
 services:
   etl:
-    image: edence/12doctubre:0-latest
+    image: edence/12doctubre:tag_name
     volumes:
       - "./log:/log"
-      - "/Users/freija/code/edence/12dOctubre/development_data:/data"
+      - "data_folder:/data"
     networks:
       - honeur_honeur-net
     environment:
@@ -14,9 +14,9 @@ services:
       DB_PORT: "5432"
       DB_DBNAME: "OHDSI"
       DB_SCHEMA: "omopcdm"
-      DB_USER: "honeur_admin"
-      DB_PASSWORD: "honeur_admin"
-      VERBOSITY_LEVEL: "0-latest"
+      DB_USER: "db_username"
+      DB_PASSWORD: "db_password"
+      VERBOSITY_LEVEL: "verbosity_level"
 
 networks:
   honeur_honeur-net:

--- a/RunETL12doctubre/docker-compose.yml
+++ b/RunETL12doctubre/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.5'
+
+services:
+  etl:
+    image: edence/12doctubre:0-latest
+    volumes:
+      - "./log:/log"
+      - "/Users/freija/code/edence/12dOctubre/development_data:/data"
+    networks:
+      - honeur_honeur-net
+    environment:
+      DB_DBMS: "postgresql"
+      DB_SERVER : "postgres"
+      DB_PORT: "5432"
+      DB_DBNAME: "OHDSI"
+      DB_SCHEMA: "omopcdm"
+      DB_USER: "honeur_admin"
+      DB_PASSWORD: "honeur_admin"
+      VERBOSITY_LEVEL: "0-latest"
+
+networks:
+  honeur_honeur-net:
+    external:
+      name: honeur-net

--- a/RunETL12doctubre/runETL.sh
+++ b/RunETL12doctubre/runETL.sh
@@ -1,0 +1,24 @@
+docker stop etl
+docker rm etl
+
+curl -L https://raw.githubusercontent.com/solventrix/Honeur-Setup/master/RunETL12doctubre/docker-compose.yml --output docker-compose.yml
+
+read -p "Input Data folder [./data]: " data_folder
+data_folder=${data_folder:-./data}
+read -p "DB username [honeur_admin]: " db_username
+db_username=${db_username:-honeur_admin}
+read -p "DB password [honeur_admin]: " db_password
+db_password=${db_password:-honeur_admin}
+read -p "Output verbosity level [INFO]: " verbosity_level
+verbosity_level=${verbosity_level:-INFO}
+read -p "Docker Hub image tag: " image_tag
+verbosity_level=${image_tag}
+
+sed -i -e "s@data_folder@$data_folder@g" docker-compose.yml
+sed -i -e "s/db_username/$db_username/g" docker-compose.yml
+sed -i -e "s/db_password/$db_password/g" docker-compose.yml
+sed -i -e "s/verbosity_level/$verbosity_level/g" docker-compose.yml
+sed -i -e "s/image_tag/$image_tag/g" docker-compose.yml
+
+docker login
+docker-compose run --rm etl

--- a/RunETL12doctubre/runETL.sh
+++ b/RunETL12doctubre/runETL.sh
@@ -11,7 +11,8 @@ read -p "DB password [honeur_admin]: " db_password
 db_password=${db_password:-honeur_admin}
 read -p "Output verbosity level [INFO]: " verbosity_level
 verbosity_level=${verbosity_level:-INFO}
-read -p "Docker Hub image tag: " image_tag
+read -p "Docker Hub image tag [current]: " image_tag
+verbosity_level=${verbosity_level:-current}
 
 sed -i -e "s@data_folder@$data_folder@g" docker-compose.yml
 sed -i -e "s/db_username/$db_username/g" docker-compose.yml

--- a/RunETL12doctubre/runETL.sh
+++ b/RunETL12doctubre/runETL.sh
@@ -12,7 +12,6 @@ db_password=${db_password:-honeur_admin}
 read -p "Output verbosity level [INFO]: " verbosity_level
 verbosity_level=${verbosity_level:-INFO}
 read -p "Docker Hub image tag: " image_tag
-verbosity_level=${image_tag}
 
 sed -i -e "s@data_folder@$data_folder@g" docker-compose.yml
 sed -i -e "s/db_username/$db_username/g" docker-compose.yml


### PR DESCRIPTION
This commit adds a `RunETL12doctubre` directory that holds the public deployment files:
 - `README.md`: instructions on how to install and run the etl
 - `docker-compose.yml`
 - `runETL.sh`: the script that will download the docker-compose file and run the etl image.

The user can supply a `tag_name` in order to download a specific image from the Docker Hub repository. The default image will be the `current` one. It also requires credentials to Docker Hub that have been given access to the `defence/12doctubre` repository.