### PR TITLE
ETL12doctubre: small changes to deployment script

### DIFF
--- a/RunETL12doctubre/runETL.sh
+++ b/RunETL12doctubre/runETL.sh
@@ -1,4 +1,4 @@
-if [ $(docker ps -a | grep etl | wc -l) = 1 ]; then
+if [ $(docker ps --filter "name=etl" | grep -w 'etl' | wc -l) = 1 ]; then
   docker stop -t 1 etl && docker rm etl;
 fi
 

--- a/RunETL12doctubre/runETL.sh
+++ b/RunETL12doctubre/runETL.sh
@@ -1,5 +1,6 @@
-docker stop etl
-docker rm etl
+if [ $(docker ps -a | grep etl | wc -l) = 1 ]; then
+  docker stop -t 1 etl && docker rm etl;
+fi
 
 curl -L https://raw.githubusercontent.com/solventrix/Honeur-Setup/master/RunETL12doctubre/docker-compose.yml --output docker-compose.yml
 
@@ -21,4 +22,5 @@ sed -i -e "s/verbosity_level/$verbosity_level/g" docker-compose.yml
 sed -i -e "s/image_tag/$image_tag/g" docker-compose.yml
 
 docker login
-docker-compose run --rm etl
+docker-compose pull
+docker-compose run --rm --name etl etl


### PR DESCRIPTION
This PR adds a few things to the deployment script:
 - `docker-compose pull` should always get the latest version of the specified tag
 - the container is now explicitly named `etl`
 - if there is a container named `etl` running, then we stop and delete it beforehand